### PR TITLE
Fixes issue 8

### DIFF
--- a/components/operations_manager.py
+++ b/components/operations_manager.py
@@ -42,8 +42,8 @@ class OperationsManager(object):
 
         info = self.definitions_database.get_operation_exec_info(id_)
 
-        extractor = self.repositories_manager.get_extractor(info['extractor_id'])
-        inspector = self.repositories_manager.get_inspector(info['inspector_id'])
+        extractor = self.repositories_manager.get_extractor(info['extractor_id'])  # TODO: Check if it raises exception
+        inspector = self.repositories_manager.get_inspector(info['inspector_id'])  # TODO: Check if it raises exception
         param_values = info['param_values']
 
         return Operation(extractor, inspector, param_values)

--- a/components/repositories_manager.py
+++ b/components/repositories_manager.py
@@ -4,20 +4,45 @@ import re
 import os
 import shutil
 
+from cybox.common import ObjectProperties
+
+from model import Extractor, Inspector
+
 
 def camel_case_to_underscore(name):
     s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
 
 
+def get_class_from_file(prefix, name, interface_class):
+    try:
+        module = import_module(prefix + camel_case_to_underscore(name))
+    except ImportError:
+        raise
+
+    try:
+        concrete_class = getattr(module, name)
+    except AttributeError:
+        raise
+
+    if not issubclass(concrete_class, interface_class):
+        raise TypeError(
+            "'{0}' must implement the '{1}' interface.".format(concrete_class.__name__, interface_class.__name__))
+
+    return concrete_class()
+
+
 class RepositoriesManager(object):
+    def __init__(self, repositories_dir_name):
+        self.repositories_dir_name = repositories_dir_name
+
     def add_file(self, repo_name, file_path):
         """
         :type repo_name: string
         :type file_path: string
         :rtype : bool
         """
-        dest_path = os.path.join('repositories', repo_name)
+        dest_path = os.path.join(self.repositories_dir_name, repo_name)
         try:
             shutil.copyfile(file_path, dest_path)
         except IOError:
@@ -29,7 +54,7 @@ class RepositoriesManager(object):
         :type file_name: string
         :rtype : bool
         """
-        target_path = os.path.join('repositories', repo_name, file_name)
+        target_path = os.path.join(self.repositories_dir_name, repo_name, file_name)
         try:
             os.remove(target_path)
         except OSError:
@@ -40,24 +65,18 @@ class RepositoriesManager(object):
         :type name: string
         :type : Extractor
         """
-        module_name = camel_case_to_underscore(name)
-        module = import_module('repositories.extractors.' + module_name)
-        return getattr(module, name)()
+        return get_class_from_file(self.repositories_dir_name + '.extractors.', name, Extractor)
 
     def get_inspector(self, name):
         """
         :type name: string
         :rtype : Inspector
         """
-        module_name = camel_case_to_underscore(name)
-        module = import_module('repositories.inspectors.' + module_name)
-        return getattr(module, name)()
+        return get_class_from_file(self.repositories_dir_name + '.inspectors.', name, Inspector)
 
     def get_custom_cybox_object(self, name):
         """
         :type name: string
         :rtype : ObjectProperties
         """
-        module_name = camel_case_to_underscore(name)
-        module = import_module('repositories.custom_cybox_objects.' + module_name)
-        return getattr(module, name)()
+        return get_class_from_file(self.repositories_dir_name + '.custom_cybox_objects.', name, ObjectProperties)

--- a/test/repositories/__init__.py
+++ b/test/repositories/__init__.py
@@ -1,0 +1,1 @@
+# coding=utf-8

--- a/test/repositories/custom_cybox_objects/__init__.py
+++ b/test/repositories/custom_cybox_objects/__init__.py
@@ -1,0 +1,1 @@
+# coding=utf-8

--- a/test/repositories/extractors/__init__.py
+++ b/test/repositories/extractors/__init__.py
@@ -1,0 +1,1 @@
+# coding=utf-8

--- a/test/repositories/extractors/invalid_extractor.py
+++ b/test/repositories/extractors/invalid_extractor.py
@@ -1,0 +1,8 @@
+# coding=utf-8
+from model import Extractor
+
+
+# Plugin class should have the same name as its module.
+class NotTheSameAsModuleNameExtractor(Extractor):
+    def execute(self, extracted_data_dir_path, param_values):
+        pass

--- a/test/repositories/extractors/invalid_extractor2.py
+++ b/test/repositories/extractors/invalid_extractor2.py
@@ -1,0 +1,8 @@
+# coding=utf-8
+from model import Extractor
+
+
+# Extractor should inherit from interface Extractor.
+class InvalidExtractor2(object):
+    def execute(self, extracted_data_dir_path, param_values):
+        pass

--- a/test/repositories/extractors/valid_extractor.py
+++ b/test/repositories/extractors/valid_extractor.py
@@ -1,0 +1,7 @@
+# coding=utf-8
+from model import Extractor
+
+
+class ValidExtractor(Extractor):
+    def execute(self, extracted_data_dir_path, param_values):
+        pass

--- a/test/repositories/inspectors/__init__.py
+++ b/test/repositories/inspectors/__init__.py
@@ -1,0 +1,1 @@
+# coding=utf-8

--- a/test/test_coordinator.py
+++ b/test/test_coordinator.py
@@ -13,7 +13,7 @@ class MyTestCase(unittest.TestCase):
         definitions_database = DefinitionsDatabase('definitions.db',
                                                    'create_db.sql',
                                                    'insert_default_operations.sql')
-        repositories_manager = RepositoriesManager()
+        repositories_manager = RepositoriesManager('repositories')
         operations_manager = OperationsManager(definitions_database, repositories_manager)
         self.coordinator = Coordinator(operations_manager)
 

--- a/test/test_operations_manager.py
+++ b/test/test_operations_manager.py
@@ -39,7 +39,7 @@ class MockedDefinitionsDatabase(object):
 class TestOperationsManager(unittest.TestCase):
     def setUp(self):
         definitions_database = MockedDefinitionsDatabase()
-        repositories_manager = RepositoriesManager()
+        repositories_manager = RepositoriesManager('repositories')
         self.operations_manager = OperationsManager(definitions_database, repositories_manager)
 
     def test_operations_manager(self):

--- a/test/test_repositories_manager.py
+++ b/test/test_repositories_manager.py
@@ -1,0 +1,20 @@
+# coding=utf-8
+from unittest import TestCase
+from components.repositories_manager import RepositoriesManager
+
+
+class TestRepositoriesManager(TestCase):
+    def setUp(self):
+        self.repositories_manager = RepositoriesManager('test.repositories')
+
+    def test_get_existing_extractor(self):
+        self.repositories_manager.get_extractor('ValidExtractor')
+
+    def test_attempt_to_get_non_existent_extractor(self):
+        self.assertRaises(ImportError, self.repositories_manager.get_extractor, 'NonExistentExtractorModule')
+
+    def test_attempt_to_get_extractor_with_different_class_name(self):
+        self.assertRaises(AttributeError, self.repositories_manager.get_extractor, 'InvalidExtractor')
+
+    def test_attempt_to_get_extractor_that_does_not_implement_the_interface(self):
+        self.assertRaises(TypeError, self.repositories_manager.get_extractor, 'InvalidExtractor2')


### PR DESCRIPTION
- Add repositories_dir_name to RepositoriesManager's constructor.
- Added verifications when getting a plugin class:
  1. Module file exists.
  2. The module has a class with the expected name.
  3. The class implements the corresponding interface.
