### PR TITLE
Use 'UTF-8' for the sqlite text factory.

### DIFF
--- a/components/definitions_database_manager.py
+++ b/components/definitions_database_manager.py
@@ -3,7 +3,7 @@ from abc import ABCMeta, abstractmethod
 from os import path
 import sqlite3
 
-from model import OperationInfo, DataSource
+from model import OperationInfo, DataSource, OperationError
 
 
 class Filter(object):


### PR DESCRIPTION
Lo correcto es utilizar unicode (específicamente 'UTF-8') en vez de 'stringbytes', según [esto](http://stackoverflow.com/questions/2392732/sqlite-python-unicode-and-non-utf-data).

Resumidamente, parece que el `text_factory` por defecto es la función `unicode()`. Este cambio hace que utilice esa función pero seteándole 'UTF-8' porque sino en algunas máquinas parece que toma ASCII u otros.

Te voy a pedir que por favor **pruebes bien** si te funciona correctamente. Los tests que tenemos no parecen probar esto. Eliminando esa línea y utilizando el text_factory por defecto a mi me siguen pasando los tests. Intentá ver los problemas de unicodes que me habías tenido, a ver si se ve bien con esto.
